### PR TITLE
Reworked Offset Updating

### DIFF
--- a/source/Platforms.hx
+++ b/source/Platforms.hx
@@ -59,8 +59,7 @@ class Platforms extends FlxSprite
                 DOWN = false;
             }
             else {
-                y += 1;
-                velocity.y = 10;
+                velocity.y = 40;
             }
         }
         if (UP) {
@@ -69,8 +68,7 @@ class Platforms extends FlxSprite
                 DOWN = true;
             }
             else {
-                y -= 1;
-                velocity.y = -10;
+                velocity.y = -40;
             }
         }
         if (LEFT) {
@@ -79,8 +77,7 @@ class Platforms extends FlxSprite
                 LEFT = false;
             }
             else {
-                x -= 1;
-                velocity.x = -10;
+                velocity.x = -40;
             }
         }
         if (RIGHT) {
@@ -89,8 +86,7 @@ class Platforms extends FlxSprite
                LEFT = true;
             }
             else {
-                x += 1;
-                velocity.x = 10;
+                velocity.x = 40;
             }
         }
     }

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -71,13 +71,10 @@ class PlayState extends FlxState
 				platform.sticky = true;
 				platform.offsetX = player.x - platform.x;
 			}
-
-			// Update offset when player position changes based on keypress
-			if (FlxG.keys.anyPressed([FlxKey.LEFT, FlxKey.RIGHT, FlxKey.A, FlxKey.D]))
-			{
-				platform.offsetX += player.x - player.last.x;
-			}
-
+			
+			// Multiply velocity by elapsed to get the player's movement each frame.
+			platform.offsetX += player.velocity.x * elapsed;
+			
 			// Allow player to drop through platform if down key pressed
 			if (FlxG.keys.anyPressed([FlxKey.DOWN])) {
 				player.y = platform.y;


### PR DESCRIPTION
This PR adjusts the platform's logic for updating the player offset. It now uses the player's velocity to update the offset, which works nicely because the velocity measures the player's movement independent of the changes caused by the moving platform.

I also adjusted the platform's movement logic so it is all based off of velocity instead of using velocity and incrementing the platform's position frame-by-frame.

This change makes the player properly accelerate and decelerate when moving on a moving platform, and makes the movement on the platform smoother overall.

See the commits for the details on specific changes!