### PR TITLE
Fix multiple collisions

### DIFF
--- a/source/Platforms.hx
+++ b/source/Platforms.hx
@@ -153,7 +153,6 @@ class Platforms extends FlxSprite
                 if (touchingSprites.members[index].returnBase() == sprite)
                 { 
                     // Exit loop and Remove from touchingSprites
-                    touchingSprites.update(elapsed);
                     touchingSprites.remove(touchingSprites.members[index], true);
                     countTouching--;
                 }

--- a/source/Platforms.hx
+++ b/source/Platforms.hx
@@ -102,6 +102,7 @@ class Platforms extends FlxSprite
         {  
             var obj = new PlatformTracker(player, (player.x - platform.x));
             touchingSprites.add(obj);
+			player.acceleration.y = heavy;
             countTouching++;
         }
         else
@@ -128,6 +129,7 @@ class Platforms extends FlxSprite
             {
                 var obj = new PlatformTracker(player, (player.x - platform.x));
                 touchingSprites.add(obj);
+				player.acceleration.y = heavy;
                 countTouching++;
             }
         }

--- a/source/Platforms.hx
+++ b/source/Platforms.hx
@@ -139,14 +139,20 @@ class Platforms extends FlxSprite
         // If there are objects touching the platform, make sure it isn't this one
         if (countTouching != 0)
         {
-            for (i in 0...countTouching)
+			// Set up an unchanging variable so the loop's duration won't change as the count decreases.
+			var originalCount:Int = countTouching;
+			
+            for (i in 0...originalCount)
             {
+				// Use i to count backward through the list indices, necessary when removing objects.
+				var index:Int = originalCount - (1 + i);
+				
                 // If this object is STILl in the list of sprites touching the platform, remove it
-                if (touchingSprites.members[i].returnBase() == sprite)
+                if (touchingSprites.members[index].returnBase() == sprite)
                 { 
                     // Exit loop and Remove from touchingSprites
-                    touchingSprites.remove(touchingSprites.members[i], true);
                     touchingSprites.update(elapsed);
+                    touchingSprites.remove(touchingSprites.members[index], true);
                     countTouching--;
                 }
             }

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -66,8 +66,8 @@ class PlayState extends FlxState
 	{
 		super.update(elapsed);
 
-		FlxG.collide(map, player);
-
+		FlxG.collide(map, sprites);
+		
 		platform.platformUpdate(elapsed, sprites, platform);
 
 		hud.update(elapsed);

--- a/source/states/PlayerAirState.hx
+++ b/source/states/PlayerAirState.hx
@@ -11,6 +11,11 @@ class PlayerAirState extends BaseState
     super();
   }
 
+  public override function enter(object:FlxObject):Void
+  {
+	object.acceleration.y = (cast FlxG.state).GRAVITY;
+  }
+  
   private override function transition(object:FlxObject):Bool
   {
     var player = cast(object, Player);
@@ -86,10 +91,5 @@ class PlayerAirState extends BaseState
     }
 
     #end // End of the conditional compilation section.
-  }
-
-  private override function exit(object:FlxObject):Void
-  {
-    object.acceleration.y = (cast FlxG.state).GRAVITY;
   }
 }

--- a/source/states/PlayerJumpState.hx
+++ b/source/states/PlayerJumpState.hx
@@ -30,6 +30,7 @@ class PlayerJumpState extends PlayerAirState
 
   public override function enter(object:FlxObject):Void
   {
+      super.enter(object);
       var player = cast(object, Player);
       player.velocity.y = -JUMP;
   }


### PR DESCRIPTION
This PR fixes a few bugs that are in the current version of Collision_Branch.
These fixes include:
 * The game no longer crashes when multiple objects leave the platform simultaneously
 * Objects in contact with the platform no longer "hop" when the platform switches from upward to downward movement.

and a few other minor things. See the commits for full details of this PR's changes!